### PR TITLE
add cache to get_driver

### DIFF
--- a/R/selenium.R
+++ b/R/selenium.R
@@ -126,9 +126,24 @@ chrome_init <- function(view = T, name = "", ua = 1){
 }
 
 #' get_driver
+#'
+#' @param port specify which port you want to connect to
+#' @param ua specify user agent id
+#' @param cache specify cache
 #' @export
+get_driver <- function(port, ua = 1, cache = NULL){
 
-get_driver <- function(port, ua = 1){
+
+  prof_args <-  c('--disable-dev-shm-usage',
+                     '--disable-gpu',
+                     glue::glue('--user-agent="{user_agents[ua]}"'))# '--no-sandbox', '--headless') #  '--window-size=1200,1800' , ,
+
+  ## if cache is given
+  if (!is.null(cache)){
+    prof_args <- c(prof_args,
+                      glue::glue('--user-data-dir=tmp/cache/{cache}'))
+  }
+
   eCaps <- list(
     chromeOptions =
       list(
@@ -137,9 +152,7 @@ get_driver <- function(port, ua = 1){
           # "download.prompt_for_download" = F
           # #"download.default_directory" = "~/extract_temp"
         ),
-        args = c('--disable-dev-shm-usage',
-                 '--disable-gpu',
-                 glue::glue('--user-agent="{user_agents[ua]}"'))# '--no-sandbox', '--headless') #  '--window-size=1200,1800' , ,
+        args = prof_args
       )
   )
 

--- a/man/get_driver.Rd
+++ b/man/get_driver.Rd
@@ -4,7 +4,14 @@
 \alias{get_driver}
 \title{get_driver}
 \usage{
-get_driver(port, ua = 1)
+get_driver(port, ua = 1, cache = NULL)
+}
+\arguments{
+\item{port}{specify which port you want to connect to}
+
+\item{ua}{specify user agent id}
+
+\item{cache}{specify cache}
 }
 \description{
 get_driver


### PR DESCRIPTION
this code ([important part](https://github.com/benjaminguinaudeau/dockeR/commit/78e78db8a8d5185c7ed0a675a984215d9afcc0b5#diff-72c512f337c0fed28ee268e7aa46b109R144)) makes it possible to save the cache of a session which will be saved within the docker container.

There is a couple of top-level function that make use of `get_driver` and they probably need to be adapted before pull request is accepted. 
